### PR TITLE
Fix string interpolation for the API key.

### DIFF
--- a/docs/02-ci-cd/references/api.mdx
+++ b/docs/02-ci-cd/references/api.mdx
@@ -23,7 +23,7 @@ export APPLICATION_ID=<YOUR APPLICATION ID>
 export API_KEY=<YOUR API KEY>
 
 curl -X POST \
--H 'Authorization: Key $API_KEY' \
+-H "Authorization: Key $API_KEY" \
 https://api-public.prod.cloud.escape.tech/applications/$APPLICATION_ID/start-scan
 ```
 


### PR DESCRIPTION
This PR simply replaces the single quotes for the API key by double quotes to enable string interpolation and properly set the Authorization HTTP header.