### PR TITLE
Fix a typo in a GitHub Action input value.

### DIFF
--- a/docs/02-ci-cd/introspection-update.mdx
+++ b/docs/02-ci-cd/introspection-update.mdx
@@ -38,7 +38,7 @@ jobs:
         with:
           application_id: ${{ secrets.ESCAPE_APPLICATION_ID }}
           api_key: ${{ secrets.ESCAPE_API_KEY }}
-          shema_file: relative/path/to/schema/from/repo/root/schema.graphql
+          schema_file: relative/path/to/schema/from/repo/root/schema.graphql
           // or
           introspection_file: relative/path/to/schema/from/repo/root/introspection.json
 ```


### PR DESCRIPTION
Thoroughly compared with the input names from `action.yml` to fix this typo.