### PR TITLE
chore/extend-authentication-iframe

### DIFF
--- a/docs/05-advanced-usage/01-authentication.mdx
+++ b/docs/05-advanced-usage/01-authentication.mdx
@@ -12,7 +12,7 @@ To use those keys properly, see [**PyMultiAuth** documentation](https://escape-t
 <iframe
   src="https://escape-technologies.github.io/py-multiauth/"
   width="100%"
-  height="21000"
+  height="20000"
   frameborder="0"
   scrolling="no"
 ></iframe>

--- a/docs/05-advanced-usage/01-authentication.mdx
+++ b/docs/05-advanced-usage/01-authentication.mdx
@@ -6,7 +6,13 @@ title: Custom Authentication
 
 Escape supports most authentication methods, using the open-source package `PyMultiAuth`.
 
-The authentification is defined by two keys in the advanced configuration: `users` and `auth`. 
+The authentification is defined by two keys in the advanced configuration: `users` and `auth`.
 To use those keys properly, see [**PyMultiAuth** documentation](https://escape-technologies.github.io/py-multiauth/), embbeded down below.
 
-<iframe src="https://escape-technologies.github.io/py-multiauth/" width="100%" height="19000" frameborder="0" scrolling="no"></iframe>
+<iframe
+  src="https://escape-technologies.github.io/py-multiauth/"
+  width="100%"
+  height="21000"
+  frameborder="0"
+  scrolling="no"
+></iframe>


### PR DESCRIPTION
![image](https://github.com/Escape-Technologies/docs/assets/7050552/30277597-4c61-42d7-abd3-e139b5111127)

The authentication iframe became too short after a multiauth feature.