### PR TITLE
Add Hive to the list of supported manifests in 08-persisted-queries.mdx

### DIFF
--- a/docs/02-api-dast/07-advanced-usage/08-persisted-queries.mdx
+++ b/docs/02-api-dast/07-advanced-usage/08-persisted-queries.mdx
@@ -65,4 +65,4 @@ If you have more that 20 persisted queries, we recommend to use the `graphql_per
 The persisted queries can be provided in two formats:
 
 - Apollo format : [Apollo persited queries manifest format](https://www.apollographql.com/docs/graphos/operations/persisted-queries/#manifest-format)
-- Hashdoc format : [Yoga persited queries format](https://the-guild.dev/graphql/yoga-server/docs/features/persisted-operations#extracting-client-operations)
+- Hashdoc format : [Yoga persited queries format](https://the-guild.dev/graphql/yoga-server/docs/features/persisted-operations#extracting-client-operations), [Hive persisted operations format](https://the-guild.dev/graphql/hive/docs/schema-registry/app-deployments#extracting-persisted-documents)


### PR DESCRIPTION
Yoga is our GraphQL server, but Hive Gateway is our Router/Gateway so I think it's worth to mention both, in case people are interested to use it in the gateway.